### PR TITLE
Add load patterns from file support

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,5 @@
+2.7192: Tue Jan 01 2021
+   - add --file parameter to 'hi'
 
 2.7191_2: Sun Mar 29 2015
    - perl v5.10 required for _ prototype

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -30,6 +30,10 @@ WriteMakefile(
                 web  => 'https://github.com/jettero/term--ansicolorx',
             }
         },
+        x_authority    => "cpan:JETTERO",
+        x_contributors => [
+            q{Sergei Zhmylev <zhmylove@cpan.org>},
+        ],
     },
 
     TEST_REQUIRES => {

--- a/bin/hi
+++ b/bin/hi
@@ -15,6 +15,7 @@ my %o; my %ol = (
     "trunc|t=i"          => "truncate the line to this many characters",
     "nixnics|noex|x"     => "don't use the nicknames from Term::ANSIColorx::Colornicknames",
     "command|c=s"        => "fork and exe this command and pipe it through hi; for SHELL = hi in Makefiles",
+    "file|f=s@"          => "read regex/color pairs from file(s)",
     "supress-cmd-say"    => "don't print the command after forking",
     "list|list-colors|l" => "list (many of) the known colors",
 );
@@ -38,7 +39,19 @@ binmode STDIN,  ":utf8";
 binmode STDOUT,  ":utf8";
 binmode STDERR,  ":utf8";
 
-our $VERSION = '2.7191_2';
+our $VERSION = '2.7192';
+
+if( $o{file} ) {
+    for my $file (@{$o{file}}) {
+        my $array;
+        unless( $array = do $file ) {
+            die "$file: $@" if $@;
+            die "$file: could not load: $!";
+        }
+        die "$file: invalid syntax" unless ref $array eq "ARRAY";
+        unshift @ARGV, @{$array};
+    }
+}
 
 my $app_invocation = $o{list} ? "list_colors" : "fire_filter";
 
@@ -56,6 +69,7 @@ hi - highlight things in a stream of output
       --trunc -t:              truncate lines to this width (argument required)
       --help -h:               this help
       --command -c:            fork and execute this command and pipe it through hi
+      --file -f:               read regex/color pairs from file(s)
 
 =head1 EXAMPLES
 
@@ -64,6 +78,21 @@ Intended as a pipe colorizer
   ps auxfw | hi jettero sky root red ^nobody orange
 
   sudo tail -f /var/log/vsftpd.log | hi CONNECT.* umber OK.UPLOAD.* lime
+
+  getent passwd | hi -f username -f shell '\d+' pink
+
+=head1 FILE
+
+Regex and color pairs may be supplied not only via parameters, but also using
+one or several external files (see L<EXAMPLES>).  Each file should contain a
+valid Perl code returns ARRAYref.  The contents of it will be prepended to
+the ARGV AS-IS, see below.
+
+  [
+      jettero             => 'sky',
+      root                => 'red',
+      '(?<=:)/[^:]+(?=:)' => 'lime',
+  ],
 
 =head1 limited Makefile support
 

--- a/lib/App/HI.pm
+++ b/lib/App/HI.pm
@@ -5,7 +5,7 @@ use strict;
 use Text::Table;
 use Term::Size;
 
-our $VERSION = '2.7191_2';
+our $VERSION = '2.7192';
 
 sub top_matter {
     my $no_extra = shift;

--- a/lib/Term/ANSIColorx/AutoFilterFH.pm
+++ b/lib/Term/ANSIColorx/AutoFilterFH.pm
@@ -36,7 +36,7 @@ sub import {
 
 use common::sense;
 
-our $VERSION = '2.7191_2';
+our $VERSION = '2.7192';
 our @EXPORT_OK = qw(filtered_handle);
 
 my %pf2t;

--- a/lib/Term/ANSIColorx/ColorNicknames.pm
+++ b/lib/Term/ANSIColorx/ColorNicknames.pm
@@ -5,7 +5,7 @@ use Term::ANSIColor qw(colorstrip uncolor);
 use common::sense;
 use base 'Exporter';
 
-our $VERSION = '2.7191_2';
+our $VERSION = '2.7192';
 
 our @FIXED       = qw(color colorvalid colored);
 our @EXPORT_OK   = qw(fix_color color colorvalid colored colorstrip uncolor);


### PR DESCRIPTION
`hi` utility lacks support for loading regex-color pairs from an external file which is completely useful for automation.
This commit introduces an ability to load one or more external file(s) and unshift their content to `@ARGV`:

```sh
$ cat users.inc
[
    'jettero' => 'sky',
    'root'    => 'yellow',
    'user\d+' => 'lime',
]
$ getent passwd | hi -f users.inc root alert
```

This also enables us to write regex with different modifiers:
```perl
[
  qr {
    DOS # some
    .*? # regex
    r   # comments
  }ix => 'umber'
]
```